### PR TITLE
Updates manifest files for Kubernetes.

### DIFF
--- a/Helm-lemp/mysql/README.md
+++ b/Helm-lemp/mysql/README.md
@@ -32,6 +32,8 @@ Includes two persistenVolumes.
 
 [TO DO PROD]
 * Create persistent elastic volumes in AWS
-* Create a path to database.sql so db can initalize upon creation.
-* Create encyption keys for secrets.
+* ~~Create a path to database.sql so db can initalize upon creation.~~
+* ~~Create encyption keys for secrets.~~
 * Lockdown mysql version dev uses latest.
+* ~~Stop logging the following message.~~ "Please use caching_sha2_password instead'
+2020-07-01T18:00:09.691399Z 908 [Warning] [MY-013360] [Server] Plugin sha256_password reported: ''sha256_pas"

--- a/Helm-lemp/mysql/dev/files/mysql.cnf
+++ b/Helm-lemp/mysql/dev/files/mysql.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default_authentication_plugin=mysql_native_password

--- a/Helm-lemp/mysql/dev/templates/configMap.yaml
+++ b/Helm-lemp/mysql/dev/templates/configMap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mysql.name" . }}-mysql-overrides
+  labels:
+    app: {{ include "mysql.name" . }}-mysql-overrides
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  mysql.cnf: |-
+{{ .Files.Get "files/mysql.cnf" | indent 4 }}

--- a/Helm-lemp/mysql/dev/templates/deployment.yaml
+++ b/Helm-lemp/mysql/dev/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mysql.fullname" . }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   selector:
     matchLabels:
@@ -41,11 +45,20 @@ spec:
         - containerPort: {{ .Values.mysqlService.port }}
           name: mysql
         volumeMounts:
+        - name: mysql-overrides
+          mountPath: /etc/mysql/conf.d/mysql.cnf
+          subPath: mysql.cnf
         - mountPath: /docker-entrypoint-initdb.d
           name: {{ .Values.persistentVolumeInitdbName }}
         - mountPath: {{ .Values.persistentVolumeMountPath }}
           name: {{ .Values.persistentVolumeClaim }}  
       volumes:
+      - name: mysql-overrides
+        configMap:
+          name: {{ include "mysql.name" . }}-mysql-overrides
+          items:
+          - key: mysql.cnf
+            path: mysql.cnf
       - name: mysql-data-disk
         persistentVolumeClaim:
           claimName: {{ .Values.persistentVolumeClaim }}

--- a/Helm-lemp/mysql/dev/templates/service.yaml
+++ b/Helm-lemp/mysql/dev/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mysql.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   ports:
   - port: {{ .Values.mysqlService.port }}

--- a/Helm-lemp/nginx-phpfpm/README.md
+++ b/Helm-lemp/nginx-phpfpm/README.md
@@ -1,19 +1,41 @@
 # Kubernetes Helm LEMP Chart : app: facingsf
 
-###Deploy nginx-phpfpm/dev Dev Environment Minikube
+Dependencies:
+* Database is a seperate helm chart, so that different dbs can be dropped into LEMP.
+  **This requires maintaining two sercets.yaml files for each chart**
+* Helm [secrets plugin] (https://github.com/zendesk/helm-secrets) / Mozzilla [SOPS](https://github.com/mozilla/sops#test-with-the-dev-pgp-key)
+* Helm [namespace plugin](https://github.com/thomastaylor312/helm-namespace)
+
+## mysql Secrets
+```./pgp``` key has been ```.gitignored```
+   -Create the folder
+   -Place you private pgp in this directory
+   - This key will be used to encrypt/decrypt your password files
+
+```./mysql/developement/.sops.yaml```
+   -place your public key id in this file.
+
+
+
+### Deploy nginx-phpfpm/dev Dev Environment Minikube
 
 1. Test nginx-phpfpm chart
 > helm template ./nginx-phpfpm/dev
 
-2. Ensure that helm is ignoring html/images files.
+2. Deploy the database first as it also deploys the secrets to be used as env vars in phpfpm.
+> helm namespace secrets install -f nginx-phpfpm/dev/secrets.yaml nginx-phpfpm ./nginx-phpfpm/dev/ -n helm-lemp
+
+3. Ensure that helm is ignoring html/images files.
 ./nginx-phpfpm/dev/.helmignore
 
-3. Install nginx-phpfpm chart
+4. Install nginx-phpfpm chart
 > helm namespace -n helm-lemp install nginx-phpfpm ./nginx-phpfpm/dev/
 
+4.1. Install with secrets plugin.
+>  helm namespace -n helm-lemp secrets upgrade -f nginx-phpfpm/dev/secrets.yaml nginx-phpfpm ./nginx-phpfpm/dev
 
-
-
+5. Update deployment/releases
+> helm namespace -n helm-lemp upgrade nginx-phpfpm ./nginx-phpfpm/dev/
 
 
 [ Notes ]
@@ -27,14 +49,43 @@ metadata:
     checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
 ```
 
-B. ./nginx-phpfpm/dev/files/public/index.html
+B. [nginx] ./nginx-phpfpm/dev/files/public/index.html
 This file is a place holder for defaulting nginx.  If it is not there and adjuments are made the container will continue to fail starting.  If this file is here at least the container will start and troubleshooting can begin. 
 
+C. [nginx] The following files are provided to test php.
+ getcreds_mysql.php : gets secrets and prints them to terminal
+ getenv_var.php : gets a single env var and prints it to terminal
+ getphp_connection.php : performs a connection to mysqldb, queries the db, and returns the values to render in browser.
 
+** Test in the following fashion: **
+* From nginx pod install curl.
+``` apk --no-cache add curl vim```
+* Test from nginx container. 
+``` curl http://localhost:8080/getcreds_mysql.php ``` 
+
+D. [php] ./Helm-lemp/nginx-phpfpm/dev/file/www.conf.example is the base config for phpfpm.  It is not used at all in the helm chart but is left here for referance.  Update any values from this file to z-overrides.conf to modify the behaviour of phpfpm.
 
 
 [ TO DO ]
-* configMap {{ template "fullname" . }}-conf contains two lines that read from .Values therefore the configMap must contain the config.  Otherwise, when using .Files.Get to pull the config the .Values are not honored.
+* [nginx & phpfpm] get base64enc working for templates/secrets.yaml
+
+* [nginx] index.php and DisplayPhotoGallery01.html.php are using the service name to query sql pod in mysqli_connect.  This service name need to be dynamic in the sense that it should write an env variable to phpfpm when the service is create.
+Example:
+```$connection = mysqli_connect("nginx-phpfpm02-mysql"```
+
+* [nginx] is using a secrets volume.  Pod should not need this since the request is now reading the env vars from the phpfpm pod.
+
+* [phpfpm] logging into mysql by updating to 'Please use caching_sha2_password instead'.
+Warning: [Warning] [MY-013360] [Server] Plugin sha256_password reported: ''sha256_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'
+
+* Push logs from /opt/bitnami/php/logs to stdout using z-overrides configMap
+
+* Suppressing the message with php
+ // Suppress mysql8.0 MY-013360
+ error_reporting(E_ALL ^ E_DEPRECATED);
+
+
+* [nginx] configMap {{ template "fullname" . }}-conf contains two lines that read from .Values therefore the configMap must contain the config.  Otherwise, when using .Files.Get to pull the config the .Values are not honored.
 
 For Example:
 

--- a/Helm-lemp/nginx-phpfpm/dev/.sops.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/.sops.yaml
@@ -1,0 +1,2 @@
+creation_rules:
+    - pgp: "E2CF825F816DA59AC5894F4739855C59BA98B794"

--- a/Helm-lemp/nginx-phpfpm/dev/Chart.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: A Helm chart for Kubernetes
 type: application
 name: helm-lemp
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2

--- a/Helm-lemp/nginx-phpfpm/dev/files/php-ini-overrides.ini
+++ b/Helm-lemp/nginx-phpfpm/dev/files/php-ini-overrides.ini
@@ -1,2 +1,4 @@
 upload_max_filesize = 100M
 post_max_size = 108M
+#error_log = /proc/self/fd/2
+error_log = /opt/bitnami/php/logs/php-fpm.log

--- a/Helm-lemp/nginx-phpfpm/dev/files/public/DisplayPhotoGallery01.html.php
+++ b/Helm-lemp/nginx-phpfpm/dev/files/public/DisplayPhotoGallery01.html.php
@@ -373,28 +373,50 @@ a:nth-child(n+7) .closed{
 
 <?php
 
-    function get_creds(){
-        $creds = parse_ini_file('../php_sql_config.ini');
-        return $creds;
+  function getcreds_mysql(){
+        # array of environment variables to retrieve from container.
+        $mysql_creds = array(
+            "MYSQL_ROOT_PASSWORD" => "",
+            "MYSQL_PASSWORD" => "",
+            "MYSQL_USER" => "",
+            "MYSQL_DATABASE" => ""
+        );
+
+        # populate mysql_creds with environment variables.
+        foreach ($mysql_creds as $key => $value) {
+            $value = getenv($key);
+            #echo "$key:$value \n";
+            $mysql_creds[$key] = $value;
+        }
+        #print_array($mysql_creds);        
+        return $mysql_creds;
     }
+
 
    function get_sqli_connect($creds){
         if(!isset($connection)){
-            $connection = mysqli_connect($creds['servername'], $creds['username'], $creds['password'], $creds['dbname']);
+            #$connection = mysqli_connect($creds['servername'], $creds['username'], $creds['password'], $creds['dbname']);
+            $connection = mysqli_connect("nginx-phpfpm02-mysql", $creds['MYSQL_USER'], $creds['MYSQL_PASSWORD'], $creds['MYSQL_DATABASE']);
+
         }
         if($connection === false){
             return mysqli_connect_error();
         }
         return $connection;
    }
-
-
-   $config = get_creds();
  
-   $link = get_sqli_connect($config);
+  // Suppress mysql8.0 MY-013360
+  error_reporting(E_ALL ^ E_DEPRECATED);
+
+  //Get credentials
+  $config = getcreds_mysql();
+
+  //Connect and select db 
+  $link = get_sqli_connect($config);
+
 	
    //Connect and select db
-   //$link = mysqli_connect("mysql", "phpfpm", "asdjI88387GHGsbyuXX9093", "wallfaces");
+   //$link = mysqli_connect("mysql", "phpfpm", "some_password", "wallfaces");
    //mysql_select_db("wallfaces");
 					
    $result = mysqli_query($link, "SELECT * FROM faceimages");
@@ -741,11 +763,15 @@ a:active {}
 	<div class="gallery">
 	
 	<?php
+           // Suppress mysql8.0 MY-013360
+           error_reporting(E_ALL ^ E_DEPRECATED);
+
            //Get credentials
-           $config = get_creds();
+           $config = getcreds_mysql();
 
            //Connect and select db 
            $link = get_sqli_connect($config);
+           //$link = mysqli_connect('mysql', 'phpfpm', 'some_password', 'wallfaces');
 
 	
 	   //Check for Paris then Run a query

--- a/Helm-lemp/nginx-phpfpm/dev/files/public/getcreds_mysql.php
+++ b/Helm-lemp/nginx-phpfpm/dev/files/public/getcreds_mysql.php
@@ -1,0 +1,14 @@
+<?php
+# array of environment variables to retrieve from container.
+$mysql_creds = array(
+    "MYSQL_ROOT_PASSWORD" => "",
+    "MYSQL_PASSWORD" => "",
+    "MYSQL_USER" => "",
+    "MYSQL_DATABASE" => "" 
+);
+
+# populate mysql_creds with environment variables.
+foreach ($mysql_creds as $key => $value) {
+    $value = getenv($key);
+    echo "$key : $value \n";
+}

--- a/Helm-lemp/nginx-phpfpm/dev/files/public/getenv_var.php
+++ b/Helm-lemp/nginx-phpfpm/dev/files/public/getenv_var.php
@@ -1,0 +1,12 @@
+<?php
+// Example use of getenv()
+$passd = getenv('MYSQL_ROOT_PASSWORD');
+echo 'getenv standard: ' .$passd .PHP_EOL;
+
+
+
+$script_name = getenv('SCRIPT_FILENAME');
+echo 'getenv script: ' .$script_name
+
+?>
+

--- a/Helm-lemp/nginx-phpfpm/dev/files/public/getphp_connection.php
+++ b/Helm-lemp/nginx-phpfpm/dev/files/public/getphp_connection.php
@@ -1,0 +1,82 @@
+<?php
+    
+    #$mysql_creds = array();
+
+    #include("getphp_connection.php");
+
+    function getcreds_mysql(){
+        # array of environment variables to retrieve from container.
+        $mysql_creds = array(
+            "MYSQL_ROOT_PASSWORD" => "",
+            "MYSQL_PASSWORD" => "",
+            "MYSQL_USER" => "",
+            "MYSQL_DATABASE" => ""
+        );
+
+        # populate mysql_creds with environment variables.
+        foreach ($mysql_creds as $key => $value) {
+            #$value = getenv($_SERVER[$key]);
+            $value = (echo $_SERVER[$key];);
+            echo "$key:$value \n";
+            $mysql_creds[$key] = $value;
+        }
+        print_array($mysql_creds);        
+        return $mysql_creds;
+    }
+
+    function print_array($some_array) {
+        foreach ($some_array as $key => $value) {
+	    echo "$key:$value \n";
+        }
+
+    }
+
+
+    function get_creds(){
+        $creds = parse_ini_file('../php_sql_config.ini');
+        return $creds;
+    }
+
+    function get_sqli_connect($creds){
+        if(!isset($connection)){
+            #$connection = mysqli_connect($creds['servername'], $creds['username'], $creds['password'], $creds['dbname']);
+            $connection = mysqli_connect("nginx-phpfpm02-mysql", $creds['MYSQL_USER'], $creds['MYSQL_PASSWORD'], $creds['MYSQL_DATABASE']);
+        }
+        if($connection === false){
+            echo "returning FALSE!\n\n\n";
+            return mysqli_connect_error();
+        }
+        #echo "connection: $connection \n";
+        return $connection;
+    }
+
+
+//Get credentials
+                     #$config = get_creds();
+                     $config = getcreds_mysql();
+                     print_array($config);
+
+                     //Connect and select db 
+                     $link = get_sqli_connect($config);
+                     #$link = mysqli_connect('K8_phpfpm_service_name', 'sql_user', 'sql_user_password', 'db_to_connect');
+
+                     //Run a queryi 
+                     $resultSF = mysqli_query($link, "SELECT * FROM faceimages WHERE `ImageLocation` = 'San Francisco, CA' AND YEAR(`ImageDate`)= '2012' AND `Notes` = 'splash' AND `Notes` != 'SIGNS and NOTES' ORDER BY `ImageDate` DESC LIMIT 3");
+
+                     //Photo1
+                     $row = mysqli_fetch_row($resultSF);
+                     echo "<img id=\"photo1\" src=\"" .$row[2]/*FileLocation*/ .$row[1]/*FileName*/ .$row[10]/*FileType*/ ."\" >";
+
+                     //Photo2
+                     $row = mysqli_fetch_row($resultSF);
+                     echo "<img id=\"photo2\" class=\"current\" src=\"" .$row[2]/*FileLocation*/ .$row[1]/*FileName*/ .$row[10]/*FileType*/ ."\" >";
+
+                     //Photo3
+                     $row = mysqli_fetch_row($resultSF);
+                     echo "<img id=\"photo3\"  src=\"" .$row[2]/*FileLocation*/ .$row[1]/*FileName*/ .$row[10]/*FileType*/ ."\" >";
+
+                     //php7.0 free the result
+                     mysqli_free_result($resultSF);
+                     mysqli_close($link);
+
+?>

--- a/Helm-lemp/nginx-phpfpm/dev/files/public/index.html
+++ b/Helm-lemp/nginx-phpfpm/dev/files/public/index.html
@@ -1,0 +1,5 @@
+<title>index.html</title>
+<head></head>
+<body>
+  <p> This is a base html test file. </p>
+</body>

--- a/Helm-lemp/nginx-phpfpm/dev/files/public/index.php
+++ b/Helm-lemp/nginx-phpfpm/dev/files/public/index.php
@@ -1,11 +1,10 @@
-<html>
-
 <?php
 session_start();
 $_SESSION["id"] = session_id();
 $_SESSION["City"] = "None, Empty";
-
 ?>
+
+<html>
 
 <head>
 
@@ -1060,14 +1059,31 @@ a:active {}
 
 <title>www.facingsf.com:home</title><!-- index2005_added.html.php --><!--FSF_PhotoStack_url_varibles02.html.php -->
 <?php
-    function get_creds(){
-        $creds = parse_ini_file('../php_sql_config.ini');
-        return $creds;
-    }
+    function getcreds_mysql(){
+        # array of environment variables to retrieve from container.
+        $mysql_creds = array(
+            "MYSQL_ROOT_PASSWORD" => "", 
+            "MYSQL_PASSWORD" => "", 
+            "MYSQL_USER" => "", 
+            "MYSQL_DATABASE" => ""
+        );
+
+        # populate mysql_creds with environment variables.
+        foreach ($mysql_creds as $key => $value) {
+            $value = getenv($key);
+            #echo "$key:$value \n";
+            $mysql_creds[$key] = $value;
+        }
+        #print_array($mysql_creds);        
+        return $mysql_creds;
+    }  
+
 
    function get_sqli_connect($creds){
         if(!isset($connection)){
-            $connection = mysqli_connect($creds['servername'], $creds['username'], $creds['password'], $creds['dbname']);
+            #$connection = mysqli_connect($creds['servername'], $creds['username'], $creds['password'], $creds['dbname']);
+            $connection = mysqli_connect("nginx-phpfpm02-mysql", $creds['MYSQL_USER'], $creds['MYSQL_PASSWORD'], $creds['MYSQL_DATABASE']);
+
         }
         if($connection === false){
             return mysqli_connect_error();
@@ -1180,12 +1196,15 @@ a:active {}
            <div id="image_stack01">
                <a href=DisplayPhotoGallery01.html.php?City=SanFran&Year=2012>
 	          <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
                      //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
  
 		     //Connect and select db 
                      $link = get_sqli_connect($config);
-                     //$link = mysqli_connect('mysql', 'phpfpm', 'asdjI88387GHGsbyuXX9093j', 'wallfaces');
+                     //$link = mysqli_connect('mysql', 'phpfpm', 'some_password', 'wallfaces');
 
 		     //Run a queryi 
 		     $resultSF = mysqli_query($link, "SELECT * FROM faceimages WHERE `ImageLocation` = 'San Francisco, CA' AND YEAR(`ImageDate`)= '2012' AND `Notes` = 'splash' AND `Notes` != 'SIGNS and NOTES' ORDER BY `ImageDate` DESC LIMIT 3");			
@@ -1213,8 +1232,11 @@ a:active {}
 	   <div id="image_stack02">
 	       <a href=DisplayPhotoGallery01.html.php?City=SanFran&Year=2011>
 	          <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
                      //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
 
                      //Connect and select db 
                      $link = get_sqli_connect($config);
@@ -1244,8 +1266,11 @@ a:active {}
           <div id="image_stack03">
 	      <a href=DisplayPhotoGallery01.html.php?City=SanFran&Year=2010>
 		 <?php
+		    // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
                     //Get credentials
-                    $config = get_creds();
+                    $config = getcreds_mysql();
 
                     //Connect and select db 
                     $link = get_sqli_connect($config);
@@ -1296,9 +1321,12 @@ a:active {}
 	   <div id="image_stack04">
 	       <a href=DisplayPhotoGallery01.html.php?City=LosAngeles&Year=2010>
                   <?php
-                     //Get credentials
-                     $config = get_creds();
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
 
+                     //Get credentials
+                     $config = getcreds_mysql();
+                     
                      //Connect and select db 
                      $link = get_sqli_connect($config);
 
@@ -1328,8 +1356,11 @@ a:active {}
            <div id="image_stack05">
                <a href=DisplayPhotoGallery01.html.php?City=NewYork&Year=2010>
 	          <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
 	             //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
 
                      //Connect and select db 
                      $link = get_sqli_connect($config);
@@ -1359,8 +1390,11 @@ a:active {}
            <div id="image_stack06">
                <a href=DisplayPhotoGallery01.html.php?City=SoutheastAsia&Year=2008>
 	          <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
 	             //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
 
                      //Connect and select db 
                      $link = get_sqli_connect($config);
@@ -1409,8 +1443,11 @@ a:active {}
 	   <div id="image_stack07">
 	       <a href=DisplayPhotoGallery01.html.php?City=CentralAmerica&Year=2010>	
 	          <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
                      //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
 
                      //Connect and select db 
                      $link = get_sqli_connect($config);
@@ -1441,8 +1478,11 @@ a:active {}
 	   <div id="image_stack08">
 	       <a href=DisplayPhotoGallery01.html.php?City=BarcelonaSpain&Year=2006>
 	          <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
 		     //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
 
                      //Connect and select db 
                      $link = get_sqli_connect($config);
@@ -1471,8 +1511,11 @@ a:active {}
            <div id="image_stack09">
 	       <a href=DisplayPhotoGallery01.html.php?City=ParisFrance&Year=2005-2006>
 		  <?php
+                     // Suppress mysql8.0 MY-013360
+                     error_reporting(E_ALL ^ E_DEPRECATED);
+
                      //Get credentials
-                     $config = get_creds();
+                     $config = getcreds_mysql();
 
                      //Connect and select db 
                      $link = get_sqli_connect($config);
@@ -1519,15 +1562,8 @@ a:active {}
 		    </div>
 		</div> <!--stack_caption_mid02 -->	
 	 	
-		
-		
-
-
-
-	 
     </div><!--page wrap-->
 </div><!--MainContent-->
-
 
 <body>
 

--- a/Helm-lemp/nginx-phpfpm/dev/files/www.conf.example
+++ b/Helm-lemp/nginx-phpfpm/dev/files/www.conf.example
@@ -1,0 +1,441 @@
+; This is the original /opt/bitnami/php/etc/php-fpm.d/www.conf file
+; It is placed here as referance.  Update z-overrides.conf with settings
+; from this file.  This file is not used in the K8's phpfpm pod/s.
+; Start a new pool named 'www'.
+; the variable $pool can be used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'access.log'
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or /usr) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = www-data
+group = www-data
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = /run/php/php7.4-fpm.sock
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 511
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+listen.owner = www-data
+listen.group = www-data
+;listen.mode = 0660
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users =
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is differrent than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+; process.dumpable = yes
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 5
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 2
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 1
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 3
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+;pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: /usr/share/php/7.4/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; Depth of slow log stack trace.
+; Default Value: 20
+;request_slowlog_trace_depth = 20
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+
+; The timeout set by 'request_terminate_timeout' ini option is not engaged after
+; application calls 'fastcgi_finish_request' or when application has finished and
+; shutdown functions are being called (registered via register_shutdown_function).
+; This option will enable timeout limit to be applied unconditionally
+; even in such cases.
+; Default Value: no
+;request_terminate_timeout_track_finished = no
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+;decorate_workers_output = no
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; execute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5 .php7
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M

--- a/Helm-lemp/nginx-phpfpm/dev/files/z-overrides.conf
+++ b/Helm-lemp/nginx-phpfpm/dev/files/z-overrides.conf
@@ -1,0 +1,31 @@
+[global]
+; Override default pid file
+pid = /run/php-fpm.pid
+
+; Avoid logs being sent to syslog
+error_log = /proc/self/fd/2
+
+; Set this to php default's max_execution_time to allow children to stop gracefully when fpm is commanded to stop
+; This helps avoiding 502's
+process_control_timeout = 30
+
+; Do not daemonize (eg send process to the background)
+daemonize = no
+
+[www]
+; Access from webserver container is via network, not socket file
+listen = [::]:9000
+
+; Redirect logs to stdout - FPM closes /dev/std* on startup
+access.log = /proc/self/fd/2
+catch_workers_output = yes
+
+; Remove "pool www" decoration from log output (older phpdocker.io containers for php use sed for this)
+decorate_workers_output = no
+
+; Required to allow config-by-environment
+clear_env = no
+env[MYSQL_ROOT_PASSWORD]=$MYSQL_ROOT_PASSWORD
+env[MYSQL_PASSWORD]=$MYSQL_PASSWORD
+env[MYSQL_USER]=$MYSQL_USER
+env[MYSQL_DATABASE]=$MYSQL_DATABASE

--- a/Helm-lemp/nginx-phpfpm/dev/secrets.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/secrets.yaml
@@ -1,0 +1,27 @@
+mysql_root_password: ENC[AES256_GCM,data:JCVmBu/S2U32iMqzGO963Idt7T1WMPk=,iv:oSCpzbBWl0aXY2m3N5dKczXrkBDwR7ORYPEe/+KJfmU=,tag:5oZMg8BqmiJ0LtZihvLHNg==,type:str]
+mysql_user: ENC[AES256_GCM,data:M+mCvV0P,iv:sqAreJw7NiuFDqnSLwiDVqgwe86hBvX7SL1AdM/x1uM=,tag:bm6lYt6KKXS+GzTS6DRXZg==,type:str]
+mysql_password: ENC[AES256_GCM,data:VXDTYTXzxNXLiV3DppTfLNC1EwIS0qs/,iv:CaQ05xIdyMHnnf6lKMjuXG/GwKsnYP6a+yeaGGXjcRI=,tag:yBxm45btyWt9OdBTCLtFFw==,type:str]
+mysql_database: ENC[AES256_GCM,data:FjOvFFCz8RMw,iv:bTPkHyT7Htm+Q/XzSorNwx2zXd5OBmUw4W8Wkv7tMlU=,tag:s+dpgIc1o1PHW2cvoe2xkw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    lastmodified: '2020-05-25T21:01:42Z'
+    mac: ENC[AES256_GCM,data:Vf8qeOkNLRqguX5djyNuezyXz4dZfWo9DANhRZ3ns3gSsO4dADbI9besqV07MCdcau9wDkOWSkGjcJPbts4wkA6fy78PGVSxySGDY76L5EeVxIA7ffGKXusAngPPp9os3ncvl4NvQ+FtdOMIpnGicZKfwDd71RRnu7NhH2BmcuY=,iv:t/xZB6TmN4FmUYeXr643i+UI3t/RkBCcoYOPgojEWLw=,tag:Y2KE0sFFz9ZPsz5AyMJ6ow==,type:str]
+    pgp:
+    -   created_at: '2020-05-25T21:01:42Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAw2SPkIgCwPgAQgAk4cKIY0K3xX5IDdJTkx45NEQjjDUDmfwv6NaqSX1Tbzw
+            R8Sqj0WlBNrhJO+FNTLZyNbUmUv7bPh8hwE61SD2A+++0pyWhhBpOsofoHS3Lqrr
+            2arkie6XkyAbH60bxcGcNWbeAocTO8qVjHdEOLF5KcYBjkvjp1mgzUTgDmtjWsop
+            lp/zcOs4oWSml8lNv62Q+rOnSMV0tE/Fnkw2jdrTQf62Z8cGAU3AWCLmvvIt2CLA
+            ko2yWVCL11UegNvUYd29+hjz+6VW685MnpXvOrz7PDTLL6fDXlwwNRa3cWYKhYDN
+            yRjDBzSmuMBzilTQ+kBz6LqfVYYRlQpKbQL6oNuSWtLgAeQH9yYjY4gUj+3dzDnm
+            j8004atl4Pvgi+HdruBs4uBYsHrgmeViOnGJlrZirsNiZRYyLQ/omQ6NW6brp9KH
+            oUb3GWUTKeCc5IrDZwsDAElWcJdSktR6g1Tibxw+suEXvAA=
+            =MFZi
+            -----END PGP MESSAGE-----
+        fp: E2CF825F816DA59AC5894F4739855C59BA98B794
+    unencrypted_suffix: _unencrypted
+    version: 3.0.3

--- a/Helm-lemp/nginx-phpfpm/dev/templates/configMap.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/templates/configMap.yaml
@@ -12,8 +12,9 @@ data:
     server {
       listen 0.0.0.0:{{ .Values.nginxService.internalPort }};
       client_max_body_size 108M;
-      root /usr/share/nginx/html;
-      index index.html index.php;
+      #root /usr/share/nginx/html;
+      root /application;
+      index index.php index.html;
 
       if (!-e $request_filename) {
          rewrite ^.*$ /index.php last;
@@ -21,10 +22,12 @@ data:
 
       location ~ \.php$ {
         fastcgi_pass {{ template "fullname" . }}-phpfpm:9000;
-        fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME /app$fastcgi_script_name;
-        fastcgi_buffers 16 16k;
-        fastcgi_buffer_size 32k;
+        #fastcgi_index index.php;
+        #fastcgi_param SCRIPT_FILENAME /application$fastcgi_script_name;
+        fastcgi_param REQUEST_METHOD $request_method;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        #fastcgi_buffers 16 16k;
+        #fastcgi_buffer_size 32k;
         include fastcgi_params;
 
       }
@@ -42,3 +45,18 @@ metadata:
 data:
   php-ini-overrides.ini: |-
 {{ .Files.Get "files/php-ini-overrides.ini" | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-php-fpm-z-overrides
+  labels:
+    app: {{ template "fullname" . }}-php-fpm-z-overrides
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  z-overrides.conf: |-
+{{ .Files.Get "files/z-overrides.conf" | indent 4 }}
+
+

--- a/Helm-lemp/nginx-phpfpm/dev/templates/deployment.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/templates/deployment.yaml
@@ -20,8 +20,30 @@ spec:
       - name: {{ template "fullname" . }}-phpfpm
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: "MYSQL_ROOT_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_root_password
+                name: {{ .Release.Name }}-auth
+          - name: "MYSQL_USER"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_user
+                name: {{ .Release.Name }}-auth
+          - name: "MYSQL_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_password
+                name: {{ .Release.Name }}-auth
+          - name: "MYSQL_DATABASE"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_database
+                name: {{ .Release.Name }}-auth
         ports:
-        - containerPort: {{ .Values.phpfpmService.phpfpmPort }}
+        - name: phpfpm-port
+          containerPort: {{ .Values.phpfpmService.phpfpmPort }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
         readinessProbe:
@@ -33,6 +55,9 @@ spec:
         - name: phpconf-overrides
           mountPath: /opt/bitnami/php/etc/conf.d/php-ini-overrides.ini
           subPath: php-ini-overrides.ini
+        - name: php-fpm-z-overrides
+          mountPath: /opt/bitnami/php/etc/php-fpm.d/php-fpm-z-overrides.conf
+          subPath: z-overrides.conf
         - name: {{ .Values.volumes.php.persistentPublicVolumeNamePhp }}
           mountPath: {{ .Values.volumes.php.persistentPublicVolumeMountPathPhp }}
       volumes:
@@ -42,6 +67,12 @@ spec:
           items:
           - key: php-ini-overrides.ini
             path: php-ini-overrides.ini
+      - name: php-fpm-z-overrides
+        configMap:
+          name: {{ template "fullname" . }}-php-fpm-z-overrides
+          items:
+          - key: z-overrides.conf
+            path: z-overrides.conf
       - name: {{ .Values.volumes.php.persistentPublicVolumeNamePhp }}
         persistentVolumeClaim:
           claimName: {{ .Values.volumes.php.persistentPublicVolumeClaimPhp }}
@@ -69,6 +100,27 @@ spec:
       - name: {{ template "fullname" . }}-nginx
         image: "nginx:1.17.8-alpine"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        env:
+          - name: "MYSQL_ROOT_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_root_password
+                name: {{ .Release.Name }}-auth
+          - name: "MYSQL_USER"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_user
+                name: {{ .Release.Name }}-auth
+          - name: "MYSQL_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_password
+                name: {{ .Release.Name }}-auth
+          - name: "MYSQL_DATABASE"
+            valueFrom:
+              secretKeyRef:
+                key:  mysql_database
+                name: {{ .Release.Name }}-auth
         ports:
         - name: http
           containerPort: {{ .Values.nginxService.internalPort }}

--- a/Helm-lemp/nginx-phpfpm/dev/templates/secrets.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/templates/secrets.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-auth
+type: Opaque
+data:
+  mysql_root_password: {{ .Values.mysql_root_password | b64enc | quote }}
+  mysql_user: {{ .Values.mysql_user | b64enc | quote }}
+  mysql_password: {{ .Values.mysql_password | b64enc | quote }}
+  mysql_database: {{ .Values.mysql_database | b64enc | quote }}

--- a/Helm-lemp/nginx-phpfpm/dev/templates/service.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/templates/service.yaml
@@ -5,11 +5,8 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
-  type: {{ .Values.phpfpmService.type }}
   ports:
     - port: {{ .Values.phpfpmService.phpfpmPort  }}
-      targetPort: {{ .Values.phpfpmService.phpfpmPort }}
-      protocol: TCP
-      name: {{ .Values.phpfpmService.name }}
   selector:
     app: {{ template "fullname" . }}-phpfpm
+  clusterIP: None

--- a/Helm-lemp/nginx-phpfpm/dev/values.yaml
+++ b/Helm-lemp/nginx-phpfpm/dev/values.yaml
@@ -13,14 +13,15 @@ nginxService:
   internalPort: 8080
 phpfpmService:
   name: phpfpm
-  type: NodePort
+  type: ClusterIP
   phpfpmPort: 9000
 
-persistentPublicVolume: public-volume
-persistentPublicVolumeClaim: public-claim 
-persistentPublicVolumeName: public-data-disc
+persistentPublicVolume: public-volume-nginx
+persistentPublicVolumeClaim: public-claim-nginx
+persistentPublicVolumeName: public-data-disc-nginx
 persistentPublicVolumeLocalStorage: "/hosthome/developer/Kubernetes/Helm-lemp/nginx-phpfpm/dev/files/public"
-persistentPublicVolumeMountPathNginx: "/usr/share/nginx/html"
+#persistentPublicVolumeMountPathNginx: "/usr/share/nginx/html"
+persistentPublicVolumeMountPathNginx: "/application"
 
 volumes:
   php:
@@ -28,7 +29,7 @@ volumes:
     persistentPublicVolumeClaimPhp: public-claim-php
     persistentPublicVolumeNamePhp: public-data-disc-php
     persistentPublicVolumeLocalStorage: "/hosthome/developer/Kubernetes/Helm-lemp/nginx-phpfpm/dev/files/public"
-    persistentPublicVolumeMountPathPhp: "/app"
+    persistentPublicVolumeMountPathPhp: "/application"
 
 
 ingress:
@@ -44,20 +45,6 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
-config:
-  nginx.conf: |-
-    server {
-      listen 0.0.0.0:8080;
-      root /app;
-      location / {
-        index index.html index.php;
-      }
-      location ~ \.php$ {
-        fastcgi_pass phpfpm-php-app-phpfpm:9000;
-        fastcgi_index index.php;
-        include fastcgi.conf;
-      }
-    }
 
 resources:
   limits:


### PR DESCRIPTION
*configMap mysql.cnf adds ability for mysql to use password.  It is necessary for mysql > 8.0.
*configMap z-ovverrides.conf overrides phpfpm www.conf allows nginx to access the env vars when querying across the proxy.
* Files added to the public repo for testing the db credentials:
     - getcreds_mysql.php
     - getenv_var.php
     - getphp_connection.php
* Updates the apps two main files index.php and DisplayPhotoGallery01.html.php to fetch the db creds from the secrets env vars attached to the phpfpm pod.
* Updates deployment.yaml for both sql and nginx-phpfpm addes volumes for configMaps